### PR TITLE
Make :above and :below move items directly above and belove the given item.

### DIFF
--- a/lib/dm-is-list/is/list.rb
+++ b/lib/dm-is-list/is/list.rb
@@ -556,14 +556,14 @@ module DataMapper
                 # -- the same as self
                 # -- already below self
                 # -- higher up than self (lower number in list)
-                ( (self == object) or (object.position > self.position) ) ? self.position : object.position
+                ( (self == object) or (object.position == self.position + 1) ) ? self.position : object.position
 
               when :below
                 # the object given, can either be:
                 # -- the same as self
                 # -- already above self
                 # -- lower than self (higher number in list)
-                ( self == object or (object.position < self.position) ) ? self.position : object.position + 1
+                ( self == object or (object.position == self.position - 1) ) ? self.position : object.position + 1
 
               when :to
                 # can only move within top and bottom positions of list

--- a/spec/integration/list_spec.rb
+++ b/spec/integration/list_spec.rb
@@ -206,6 +206,13 @@ describe 'DataMapper::Is::List' do
             end
           end
 
+          it "should move item directly :above another in list even if it's already above it" do
+            DataMapper.repository(:default) do |repos|
+              Todo.get(2).move(:above => Todo.get(4) ).should == true
+              todo_list.should == [ [1, 1], [3, 2], [2, 3], [4, 4], [5, 5] ]
+            end
+          end
+
           it "should NOT move item :above itself" do
             DataMapper.repository(:default) do |repos|
               Todo.get(1).move(:above => Todo.get(1) ).should == false
@@ -235,6 +242,13 @@ describe 'DataMapper::Is::List' do
             DataMapper.repository(:default) do |repos|
               Todo.get(2).move(:below => Todo.get(3) ).should == true
               todo_list.should == [ [1, 1], [3, 2], [2, 3], [4, 4], [5, 5] ]
+            end
+          end
+
+          it "should move item directly :below another in list even if it's already below it" do
+            DataMapper.repository(:default) do |repos|
+              Todo.get(4).move(:below => Todo.get(2) ).should == true
+              todo_list.should == [ [1, 1], [2, 2], [4, 3], [3, 4], [5, 5] ]
             end
           end
 


### PR DESCRIPTION
Hi,

I noticed that when using :below and :above does not move items if the given item is already below or above the target item. So:

```
    [1 2 3 4 5]
```

Moving '2' above '4' would do nothing, since '2' is already above '4'. However, I feel that moving '2' above '4' should place it directly above it, and resulting in:

```
    [1 3 2 4 5]
```

Same holds for :below. I've created tests for these cases and altered the code.

Kind regards,
Roel
