### PR TITLE
fix error with finding last element

### DIFF
--- a/lib/dm-is-list/is/list.rb
+++ b/lib/dm-is-list/is/list.rb
@@ -542,7 +542,7 @@ module DataMapper
             prepos = original_attributes[properties[:position]] || position
 
             # set the last position in the list or previous position if the last item
-            maxpos = (last = list.last) ? (last == self ? prepos : last.position + 1) : minpos
+            maxpos = (last = list.last) ? (last == self ? prepos : (last.position || 0) + 1) : minpos
 
             newpos = case action
               when :highest     then minpos


### PR DESCRIPTION
When I have nested attributes in model and dm-is-list plugin and when I want create first object with nested attributes I'm getting error that + can't be use for nil.
