### PR TITLE
Add short travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.2.1
   - ruby-head
   - jruby-head
-  - rbx-head
+  - rbx
 notifications:
   irc: "irc.freenode.org#datamapper"
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ bundler_args: --without yard guard metrics benchmarks
 script: "bundle exec rake spec"
 rvm:
   - 2.0.0
+  - 2.1.5
+  - 2.2.1
   - ruby-head
   - jruby-head
   - rbx-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+bundler_args: --without yard guard metrics benchmarks
+script: "bundle exec rake spec"
+rvm:
+  - 2.0.0
+  - ruby-head
+  - jruby-head
+  - rbx-head
+notifications:
+  irc: "irc.freenode.org#datamapper"
+  email:
+    - dan.kubb@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.2.1
   - ruby-head
   - jruby-head
-  - rbx
+  - rbx-2
 notifications:
   irc: "irc.freenode.org#datamapper"
   email:

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 require 'pathname'
 
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 

--- a/dm-is-list.gemspec
+++ b/dm-is-list.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('dm-adjust', '~> 1.3.0.beta')
 
   gem.add_development_dependency('rake',  '~> 0.9.2')
-  gem.add_development_dependency('rspec', '~> 1.3.2')
+  gem.add_development_dependency('rspec', '~> 3.2.0')
 end

--- a/spec/integration/list_spec.rb
+++ b/spec/integration/list_spec.rb
@@ -521,7 +521,7 @@ describe 'DataMapper::Is::List' do
 
             item.original_list_scope.should == { :user_id => @u1.id }
             item.list_scope.should == { :user_id => @u1.id }
-            # item.list_scope.should != item.original_list_scope  # FAIL. accepts both != and ==
+            # item.list_scope.should_not == item.original_list_scope  # FAIL. accepts both != and ==
             item.position.should == nil
 
             todo_list.should == [[1, 1], [2,nil], [3, 2], [4, 3], [5, 4]]
@@ -538,7 +538,7 @@ describe 'DataMapper::Is::List' do
 
             item.original_list_scope.should == { :user_id => @u1.id }
             item.list_scope.should == { :user_id => @u1.id }
-            # item.list_scope.should != item.original_list_scope  # FAIL. accepts both != and ==
+            # item.list_scope.should_not == item.original_list_scope  # FAIL. accepts both != and ==
             item.position.should == nil
 
             todo_list.should == [[1, 1], [2,nil], [3, 2], [4, 3], [5, 4]]
@@ -834,9 +834,10 @@ describe 'DataMapper::Is::List' do
             item.user.should == @u1
 
             item.user = @u2
+            item.list_scope.should_not == item.original_list_scope
+
             item.save
 
-            item.list_scope.should != item.original_list_scope
             item.list_scope.should == { :user_id => @u2.id }
             item.position.should == 2
 
@@ -854,9 +855,9 @@ describe 'DataMapper::Is::List' do
 
             item.position = nil  #  NOTE:: Creates a messed up original list.
             item.user = @u2
-            item.save
+            item.list_scope.should_not == item.original_list_scope
 
-            item.list_scope.should != item.original_list_scope
+            item.save
             item.list_scope.should == { :user_id => @u2.id }
             item.position.should == 4
 
@@ -874,9 +875,7 @@ describe 'DataMapper::Is::List' do
 
       describe "STI inheritance" do
 
-        it "should have some tests" do
-          pending
-        end
+        it "should have some tests"
 
       end #/ STI inheritance
 
@@ -979,8 +978,8 @@ describe 'DataMapper::Is::List' do
           end
         end
 
-        it "should move items :higher in list" do
-          pending "Failing Test: Error = [ columns position, client_id are not unique ] (See notes in spec)"
+        xit "should move items :higher in list" do
+          # pending "Failing Test: Error = [ columns position, client_id are not unique ] (See notes in spec)"
           # NOTE:: This error happens because of the :unique_index => position setting.
           # Most likely the reason is due to the order of updates to the position attribute in the DB is NOT
           # fully consistant, and clashes therefore occur.
@@ -994,8 +993,8 @@ describe 'DataMapper::Is::List' do
           end
         end
 
-        it "should move items :lower in list" do
-          pending "Failing Test: Error = [ columns position, client_id are not unique ] (See notes in spec)"
+        xit "should move items :lower in list" do
+          # pending "Failing Test: Error = [ columns position, client_id are not unique ] (See notes in spec)"
           DataMapper.repository(:default) do |repos|
             ClientTodo.get(9).move(:lower).should == true
             ClientTodo.all.map{ |a| [a.id, a.position] }.should == (1..8).map { |n| [n,n] } + [ [9, 10], [10, 9] ] + (11..@loop).map { |n| [n,n] }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,7 +42,7 @@ module TodoListHelper
   end
 end
 
-Spec::Runner.configure do |config|
+RSpec.configure do |config|
   config.extend(DataMapper::Spec::Adapters::Helpers)
   config.send(:include, TodoListHelper)
 end

--- a/tasks/spec.rake
+++ b/tasks/spec.rake
@@ -4,35 +4,8 @@ spec_defaults = lambda do |spec|
   spec.spec_opts << '--options' << 'spec/spec.opts'
 end
 
-begin
-  require 'spec/rake/spectask'
+require 'rspec/core/rake_task'
 
-  Spec::Rake::SpecTask.new(:spec, &spec_defaults)
-rescue LoadError
-  task :spec do
-    abort 'rspec is not available. In order to run spec, you must: gem install rspec'
-  end
-end
-
-begin
-  require 'rcov'
-  require 'spec/rake/verify_rcov'
-
-  Spec::Rake::SpecTask.new(:rcov) do |rcov|
-    spec_defaults.call(rcov)
-    rcov.rcov      = true
-    rcov.rcov_opts = File.read('spec/rcov.opts').split(/\s+/)
-  end
-
-  RCov::VerifyTask.new(:verify_rcov => :rcov) do |rcov|
-    rcov.threshold = 100
-  end
-rescue LoadError
-  %w[ rcov verify_rcov ].each do |name|
-    task name do
-      abort "rcov is not available. In order to run #{name}, you must: gem install rcov"
-    end
-  end
-end
+RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec


### PR DESCRIPTION
Based on @envygeeks' commit in the release-1.2 branch. This removes old 1.8/1.9 and ree version which we don't plan to support (since they aren't supported by ruby any longer).